### PR TITLE
Update main

### DIFF
--- a/main
+++ b/main
@@ -5,7 +5,7 @@
 
 module load singularity 2> /dev/null
 
-singularity exec -e docker://brainlife/dipy:0.13 ./main.py
+SINGULARITYENV_PYTHONNOUSERSITE=true singularity exec -e docker://brainlife/dipy:0.13 ./main.py
 #singularity exec -e docker://nipype/nipype ./main.py
 
 if [ -s track.trk ] 


### PR DESCRIPTION
Added SINGULARITYENV_PYTHONNOUSERSITE=true to prevent singularity from using host's ~/.local/lib/pyhthon2.7 content.

Without this, the following error could occur.

```
[0mTraceback (most recent call last):
  File "/N/dc2/scratch/hayashis/test-carbonate-workflow/5bc4c6abd7daf1002b04ba04/5bc4c7f5d7daf1002b04ba0b/main.py", line 2, in <module>
    import h5py
  File "/N/u/hayashis/Carbonate/.local/lib/python2.7/site-packages/h5py/__init__.py", line 26, in <module>
    from . import _errors
ImportError: /N/u/hayashis/Carbonate/.local/lib/python2.7/site-packages/h5py/_errors.so: undefined symbol: PyUnicodeUCS2_FromStringAndSize
```